### PR TITLE
fix: inadvertent number input value change

### DIFF
--- a/src/components/param/compact.tsx
+++ b/src/components/param/compact.tsx
@@ -68,7 +68,6 @@ export function CompactParam({
       invalid={parsedValue === INVALID}
     >
       <Field.Input
-        type="number"
         inputMode="numeric"
         placeholder="Compact"
         value={value}

--- a/src/components/param/primitive.tsx
+++ b/src/components/param/primitive.tsx
@@ -59,7 +59,6 @@ export function PrimitiveParam({
     (primitive: keyof typeof integerPrimitives) =>
       ({
         ...commonProps,
-        type: "number",
         inputMode: "numeric",
         min:
           typeof integerPrimitives[primitive].min === "number"


### PR DESCRIPTION
Input mode `number` caused value to change on wheel event.

This is okay for most cases, but is annoying when editing big extrinsic.

Resolves #136 